### PR TITLE
Fixed missing indent in sftp-container resource definition.

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -81,7 +81,7 @@ spec:
             tcpSocket:
               port: 22
           resources:
-            {{- toYaml .Values.resources.sftp | indent 12 }}
+            {{- toYaml .Values.resources.sftp | nindent 12 }}
         {{- if .Values.debug.enabled }}
         - name: debug
           image: {{ .Values.debug.image.repository }}:{{ .Values.debug.image.tag }}


### PR DESCRIPTION
`0.3.0` is currently running already and can be tagged/released.