### PR TITLE
Multi-user support + Init script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## pre 1.0
 
+### 0.4.0
+
+ * Added support for multiple users having different passwords and mounting different paths on a persistent volume
+ * Added support for init script
+
 ### 0.3.0
 
 * Added `NET_ADMIN` capabilities to the sftp-server container.

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A helm chart for a SFTP server
 name: sftp-server
-version: 0.3.0
+version: 0.4.0

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 A helm chart for a SFTP server.
 
+This chart is a fork of [openvnf/sftp-server](https://github.com/openvnf/sftp-server)
+The extra features added in this fork:
+- Included pull request fixing a missing indent in sftp-container resource definition (https://github.com/openvnf/sftp-server/pull/6)
+- Support for multiple users having different passwords and mounting different paths on a persistent volume. This allows to configure 2 users, one for external, more limited access, and one for internal, less limited access
+- Support for init script
+- Changing the default image to atmoz/sftp
+
 
 ## Introduction
 
@@ -52,21 +59,24 @@ The following table lists the configurable parameters of the SFTP server chart a
 | `service.enabled`                  | If true, expose as Service                 | `true`                                      |
 | `service.type`                     | Type of exposed Service                    | `ClusterIP`                                 |
 | `service.port`                     | Port to expose Service                     | `22`                                        |
-| `sftpConfig.username`              | SFTP username                              | `sftp`                                      |
-| `sftpConfig.password`              | SFTP password for user                     | `""`                                        |
-| `sftpConfig.encrypted`             | If true, password is given as hash         | `false`                                     |
-| `sftpConfig.uid`                   | UID of SFTP user                           | `1000`                                      |
-| `sftpConfig.gid`                   | GID of SFTP user                           | `100`                                       |
+| `sftpConfig.users.username`        | SFTP username                              | `sftp`                                      |
+| `sftpConfig.users.password`        | SFTP password for user                     | `""`                                        |
+| `sftpConfig.users.encrypted`       | If true, password is given as hash         | `false`                                     |
+| `sftpConfig.users.uid`             | UID of SFTP user                           | `1000`                                      |
+| `sftpConfig.users.gid`             | GID of SFTP user                           | `100`                                       |
+| `sftpConfig.users.authorizedKeys`  | list of authorized SSH keys                | `{}`                                        |
+| `sftpConfig.users.mountPath`       | Path to mount an existing volume           | `"/home/sftp/ftp"`                          |
+| `sftpConfig.users.subPath`         | Use subPath of existing volume             | `""`                                        |
 | `sftpConfig.hostKeys.secret`       | name of secret for SSH host keys           | `""`                                        |
 | `sftpConfig.hostKeys.keys`         | list of items to be used from secret       | `{}`                                        |
-| `sftpConfig.authorizedKeys`        | list of authorized SSH keys                | `{}`                                        |
 | `persistentVolume.enabled`         | If true, use persistent volume             | `true`                                      |
 | `persistentVolume.annotations`     | annotations put on the volume              | `{}`                                        |
 | `persistentVolume.accessModes`     | access modes for volume                    | `[ReadWriteOnce]`                           |
 | `persistentVolume.existingClaim`   | If set, use existing PVC                   | `""`                                        |
 | `persistentVolume.size`            | Size of volume                             | `20Gi`                                      |
 | `persistentVolume.storageClass`    | StorageClass to be used in PVC             | not set                                     |
-| `persistentVolume.subPath`         | Use subPath of existing volume             | `""`                                        |
+| `init.enabled`                     | If true, use an init script                | `false`                                     |
+| `init.script`                      | The content of init script                 | `""`                                        |
 | `vxlanController.enabled`          | If enabled, start kube-vxlan-controller    | `false`                                     |
 | `vxlanController.annotationKey`    | Annotation name to set for vxlan           | `vxlan.openvnf.org/networks`                |
 | `vxlanController.metadataKey`      | Metadata key to set for vxlan              | `vxlan.openvnf.org`                         |

--- a/templates/authorized-keys-config.yaml
+++ b/templates/authorized-keys-config.yaml
@@ -1,11 +1,15 @@
-{{- if .Values.sftpConfig.authorizedKeys }}
+{{- $fullname := include "sftp-server.fullname" . }}
+{{- range $user := .Values.sftpConfig.users }}
+{{- if $user.authorizedKeys }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "sftp-server.fullname" . }}-authorized-keys
+  name: {{ $fullname }}-{{ $user.username }}-authorized-keys
 data:
   id_rsa.pub: |
-    {{- range .Values.sftpConfig.authorizedKeys }}
+    {{- range $user.authorizedKeys }}
     {{ . }}
     {{- end }}
+{{- end }}
+---
 {{- end }}

--- a/templates/custom-script-config.yaml
+++ b/templates/custom-script-config.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.init.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "sftp-server.fullname" . }}-init
+data:
+  init.sh: {{- toYaml .Values.init.script | indent 2 }}
+{{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -1,3 +1,5 @@
+{{- $fullname := include "sftp-server.fullname" . }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -57,15 +59,19 @@ spec:
             - name: sftp-config
               mountPath: /etc/sftp/
             {{- if .Values.persistentVolume.enabled }}
+            {{- range $user := .Values.sftpConfig.users }}
             - name: data
-              mountPath: /home/ {{- .Values.sftpConfig.username -}} /
-              {{- if .Values.persistentVolume.subPath }}
-              subPath: "{{ .Values.persistentVolume.subPath }}"
+              mountPath: {{ $user.mountPath }}
+              {{- if $user.subPath }}
+              subPath: "{{ $user.subPath }}"
               {{- end }}
             {{- end }}
-            {{- if .Values.sftpConfig.authorizedKeys }}
-            - name: authorized-keys
-              mountPath: /home/ {{- .Values.sftpConfig.username -}} /.ssh/keys/
+            {{- end }}
+            {{- range $user := .Values.sftpConfig.users }}
+            {{- if $user.authorizedKeys }}
+            - name: authorized-keys-{{ $user.username }}
+              mountPath: /home/{{ $user.username }}/.ssh/keys/
+            {{- end }}
             {{- end }}
             {{- if .Values.sftpConfig.hostKeys }}
             {{- range .Values.sftpConfig.hostKeys.keys }}
@@ -74,6 +80,11 @@ spec:
               subPath: {{ . }}
             {{- end }}
             {{- end }}
+            {{- if .Values.init.enabled }}
+            - name: init-script
+              mountPath: /etc/sftp.d/init.sh
+              subPath: init.sh
+            {{- end }}
           livenessProbe:
             tcpSocket:
               port: 22
@@ -81,7 +92,7 @@ spec:
             tcpSocket:
               port: 22
           resources:
-            {{- toYaml .Values.resources.sftp | indent 12 }}
+            {{- toYaml .Values.resources.sftp | nindent 12 }}
         {{- if .Values.debug.enabled }}
         - name: debug
           image: {{ .Values.debug.image.repository }}:{{ .Values.debug.image.tag }}
@@ -111,10 +122,12 @@ spec:
       - name: sftp-config
         configMap:
           name: {{ include "sftp-server.fullname" . }}-users
-      {{- if .Values.sftpConfig.authorizedKeys }}
-      - name: authorized-keys
+      {{- range $user := .Values.sftpConfig.users }}
+      {{- if $user.authorizedKeys }}
+      - name: authorized-keys-{{ $user.username }}
         configMap:
-          name: {{ template "sftp-server.fullname" . }}-authorized-keys
+          name: {{ $fullname }}-{{ $user.username }}-authorized-keys
+      {{- end }}
       {{- end }}
       {{- if .Values.sftpConfig.hostKeys }}
       - name: ssh-host-keys
@@ -123,6 +136,12 @@ spec:
           defaultMode: 384
       {{- end }}
       {{- if .Values.persistentVolume.enabled }}
+      {{- if .Values.init.enabled }}
+      - name: init-script
+        configMap:
+          name: {{ include "sftp-server.fullname" . }}-init
+          defaultMode: 0775
+      {{- end }}
       - name: data
         persistentVolumeClaim:
           claimName: {{ if .Values.persistentVolume.existingClaim }}{{ .Values.persistentVolume.existingClaim }}{{- else }}{{ template "sftp-server.fullname" . }}-data{{- end }}

--- a/templates/sftp-config.yaml
+++ b/templates/sftp-config.yaml
@@ -4,8 +4,10 @@ metadata:
   name: {{ template "sftp-server.fullname" . }}-users
 data:
   users.conf: |
-      {{- if eq .Values.sftpConfig.encrypted true }}
-      {{ .Values.sftpConfig.username }}:{{ .Values.sftpConfig.password }}:e:{{ .Values.sftpConfig.uid}}:{{ .Values.sftpConfig.gid }}
+      {{- range $user := .Values.sftpConfig.users }}
+      {{- if eq $user.encrypted true }}
+      {{ $user.username }}:{{ $user.password }}:e:{{ $user.uid}}:{{ $user.gid }}
       {{- else }}
-      {{ .Values.sftpConfig.username }}:{{ .Values.sftpConfig.password }}:{{ .Values.sftpConfig.uid}}:{{ .Values.sftpConfig.gid }}
+      {{ $user.username }}:{{ $user.password }}:{{ $user.uid}}:{{ $user.gid }}
+      {{- end }}
       {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: quay.io/openvnf/sftp
+  repository: atmoz/sftp
   tag: alpine-3.7
   pullPolicy: IfNotPresent
 
@@ -16,17 +16,36 @@ service:
   port: 22
 
 sftpConfig:
-  username: sftp
-  password: ""
-  encrypted: false
-  uid: ""
-  gid: ""
+  users:
+    - username: sftp
+      password: ""
+      encrypted: false
+      uid: ""
+      gid: ""
+      authorizedKeys: {}
+      mountPath: "/home/sftp/ftp"
+      #subPath: "inbox" # mounts to a subfolder "inbox" on a persistent volume. This user will only be able to access "inbox subfolder"
+    #- username: sftp-admin
+    #  password: ""
+    #  encrypted: false
+    #  uid: ""
+    #  gid: ""
+    #  authorizedKeys: {}
+    #  mountPath: /home/sftp-admin/ftp # this user will see all subfolders on a persistent volume
   hostKeys: {}
-    #secret: name-of-existing-secret
-    #keys:
-    #- ssh_host_rsa_key
-    #- ssh_host_ed25519_key
-  authorizedKeys: {}
+    # secret: name-of-existing-secret
+    # keys:
+    # - ssh_host_rsa_key
+    # - ssh_host_ed25519_key
+
+init:
+  enabled: false
+  #script: |
+  #  #!/bin/bash
+  #  if ! [ -d /home/sftp/ftp/inbox ]; then
+  #    mkdir /home/sftp/ftp/inbox
+  #  fi  
+  #  chmod -R a+rw /home/sftp/ftp
 
 debug:
   enabled: false
@@ -43,7 +62,6 @@ persistentVolume:
   existingClaim: ""
   size: 20Gi
   # storageClass: "-"
-  subPath: ""
 
 vxlanController:
   enabled: false


### PR DESCRIPTION
I recently tried to use this helm chart and ran into some limitations. I made some improvements I needed in the fork. If you like them, please feel free to accept the pull request. If not, feel free to simply pick the pieces you liked.

Improvements:
- Included pull request fixing a missing indent in sftp-container resource definition (https://github.com/openvnf/sftp-server/pull/6)
- Support for multiple users having different passwords and mounting different paths on a persistent volume. This allows to configure 2 users, one for external, more limited access, and one for internal, less limited access
- Support for init script
- I also changed the default image to atmoz/sftp