### PR TITLE
optional user dir

### DIFF
--- a/templates/sftp-config.yaml
+++ b/templates/sftp-config.yaml
@@ -5,7 +5,7 @@ metadata:
 data:
   users.conf: |
       {{- if eq .Values.sftpConfig.encrypted true }}
-      {{ .Values.sftpConfig.username }}:{{ .Values.sftpConfig.password }}:e:{{ .Values.sftpConfig.uid}}:{{ .Values.sftpConfig.gid }}
+      {{ .Values.sftpConfig.username }}:{{ .Values.sftpConfig.password }}:e:{{ .Values.sftpConfig.uid}}:{{ .Values.sftpConfig.gid }}:{{ .Values.sftpConfig.dir }}
       {{- else }}
-      {{ .Values.sftpConfig.username }}:{{ .Values.sftpConfig.password }}:{{ .Values.sftpConfig.uid}}:{{ .Values.sftpConfig.gid }}
+      {{ .Values.sftpConfig.username }}:{{ .Values.sftpConfig.password }}:{{ .Values.sftpConfig.uid}}:{{ .Values.sftpConfig.gid }}:{{ .Values.sftpConfig.dir }}
       {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -21,6 +21,7 @@ sftpConfig:
   encrypted: false
   uid: ""
   gid: ""
+  dir: ""
   hostKeys: {}
     #secret: name-of-existing-secret
     #keys:


### PR DESCRIPTION
This helps me starting sftp server that can be used right away. Since `atmoz/sftp` does not allow a user to write to the "base" ftp folder, it is not easy to deploy sftp server that can be written into without any action... I tested it both with : 
 - `dir: ""` which resolves into `sftp:test:::` in `/etc/sftp/users.conf` which seems to be valid and working
 - `dir: "uploads"` which results in creation of that dir and allows the user to write to it 