### PR TITLE
Fix resource definitions and container order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## pre 1.0
 
+### 0.3.1
+
+* Move debug container to first position to make it the default target for container attachments.
+* Fix inclusion of resource definitions.
+
 ### 0.3.0
 
 * Added `NET_ADMIN` capabilities to the sftp-server container.

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A helm chart for a SFTP server
 name: sftp-server
-version: 0.3.0
+version: 0.3.1

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -80,8 +80,6 @@ spec:
           readinessProbe:
             tcpSocket:
               port: 22
-          resources:
-            {{- toYaml .Values.resources.sftp | indent 12 }}
         {{- if .Values.debug.enabled }}
         - name: debug
           image: {{ .Values.debug.image.repository }}:{{ .Values.debug.image.tag }}
@@ -96,6 +94,7 @@ spec:
           - -c
           - "trap : TERM INT; (while true; do sleep 1000; done) & wait"
         {{- end }}
+          resources: {{- toYaml .Values.resources.sftp | nindent 12 }}
         {{- if .Values.vxlanController.enabled }}
         - name: vxlan-controller-agent
           image: {{ .Values.vxlanController.image.repository }}:{{ .Values.vxlanController.image.tag }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -43,6 +43,19 @@ spec:
             add: ["NET_ADMIN"]
       {{- end }}
       containers:
+        {{- if .Values.debug.enabled }}
+        - name: debug
+          image: {{ .Values.debug.image.repository }}:{{ .Values.debug.image.tag }}
+          imagePullPolicy: {{ .Values.debug.image.pullPolicy | quote }}
+          resources: {{- toYaml .Values.resources.debug | nindent 12 }}
+          securityContext:
+            capabilities:
+              add: ["NET_ADMIN"]
+          command:
+          - sh
+          - -c
+          - "trap : TERM INT; (while true; do sleep 1000; done) & wait"
+        {{- end }}
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -80,20 +93,6 @@ spec:
           readinessProbe:
             tcpSocket:
               port: 22
-        {{- if .Values.debug.enabled }}
-        - name: debug
-          image: {{ .Values.debug.image.repository }}:{{ .Values.debug.image.tag }}
-          imagePullPolicy: {{ .Values.debug.image.pullPolicy | quote }}
-          resources:
-  {{ toYaml .Values.resources.debug | indent 10 }}
-          securityContext:
-            capabilities:
-              add: ["NET_ADMIN"]
-          command:
-          - sh
-          - -c
-          - "trap : TERM INT; (while true; do sleep 1000; done) & wait"
-        {{- end }}
           resources: {{- toYaml .Values.resources.sftp | nindent 12 }}
         {{- if .Values.vxlanController.enabled }}
         - name: vxlan-controller-agent


### PR DESCRIPTION
* Indentations of resource definitions for SFTP- and debug-containers were wrong resuting in them being ignored. 
* Change container order to make debug container default attachment target.