### PR TITLE
Add support for custom scripts

### DIFF
--- a/templates/custom-scripts.yaml
+++ b/templates/custom-scripts.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.sftpConfig.customScripts }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "sftp-server.fullname" . }}-custom-scripts
+data:
+  {{- range $k, $v := .Values.sftpConfig.customScripts }}
+  {{ $k }}: {{ $v | toYaml | indent 2 }}
+  {{- end }}
+{{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -87,6 +87,10 @@ spec:
               subPath: {{ . }}
             {{- end }}
             {{- end }}
+            {{- if .Values.sftpConfig.customScripts }}
+            - name: custom-scripts
+              mountPath: /etc/sftp.d
+            {{- end }}
           livenessProbe:
             tcpSocket:
               port: 22
@@ -119,6 +123,12 @@ spec:
         secret:
           secretName: {{ .Values.sftpConfig.hostKeys.secret }}
           defaultMode: 384
+      {{- end }}
+      {{- if .Values.sftpConfig.customScripts }}
+      - name: custom-scripts
+        configMap:
+          name: {{ include "sftp-server.fullname" . }}-custom-scripts
+          defaultMode: 0755
       {{- end }}
       {{- if .Values.persistentVolume.enabled }}
       - name: data

--- a/values.yaml
+++ b/values.yaml
@@ -27,6 +27,7 @@ sftpConfig:
     #- ssh_host_rsa_key
     #- ssh_host_ed25519_key
   authorizedKeys: {}
+  #customScripts: {}
 
 debug:
   enabled: false


### PR DESCRIPTION
This change adds support for putting custom scripts in `/etc/sftp.d` with the `sftpConfig.customScripts` Helm value.

Upstream `atmoz/sftp` [looks](https://github.com/atmoz/sftp/blob/9e09e0464fbf3fdb8d13f080a733b5c834e55d09/files/entrypoint#L82) in `/etc/sftp.d` for executables and runs them.